### PR TITLE
Zmiany pod multifield

### DIFF
--- a/src/Mmi/Form/Element/ElementAbstract.php
+++ b/src/Mmi/Form/Element/ElementAbstract.php
@@ -30,6 +30,11 @@ use Mmi\Mvc\View;
  */
 abstract class ElementAbstract extends \Mmi\OptionObject
 {
+    /**
+     * Nazwa elementu
+     * @var string
+     */
+    protected $_baseName;
 
     /**
      * Błędy pola
@@ -67,7 +72,7 @@ abstract class ElementAbstract extends \Mmi\OptionObject
      */
     protected $_renderingOrder = ['fetchBegin', 'fetchLabel', 'fetchField', 'fetchDescription', 'fetchErrors', 'fetchEnd'];
 
-    /** 
+    /**
      * @var View
      */
     protected $view;
@@ -91,6 +96,7 @@ abstract class ElementAbstract extends \Mmi\OptionObject
     {
         //ustawia nazwę i opcje domyślne
         $this->setName($name)
+            ->setBaseName($name)
             ->setRequired(false)
             ->setRequiredAsterisk('*')
             ->setLabelPostfix(':')
@@ -99,6 +105,27 @@ abstract class ElementAbstract extends \Mmi\OptionObject
             ->addClass('field');
         //@TODO: some day better injection (container independent)
         $this->view = App::$di->get(View::class);
+    }
+
+    /**
+     * Ustawia nazwę podstawową
+     * @return string
+     */
+    public function getBaseName()
+    {
+        return $this->_baseName;
+    }
+
+    /**
+     * Pobiera nazwę podstawową
+     * @param string $baseName
+     * @return $this
+     */
+    public function setBaseName(string $baseName)
+    {
+        $this->_baseName = $baseName;
+
+        return $this;
     }
 
     /**
@@ -151,7 +178,6 @@ abstract class ElementAbstract extends \Mmi\OptionObject
      */
     public function onFormSaved()
     {
-
     }
 
     /**
@@ -160,7 +186,6 @@ abstract class ElementAbstract extends \Mmi\OptionObject
      */
     public function onRecordSaved()
     {
-
     }
 
     /**
@@ -180,7 +205,7 @@ abstract class ElementAbstract extends \Mmi\OptionObject
      */
     public final function setIgnore($ignore = true)
     {
-        return $this->setOption('data-ignore', (bool) $ignore);
+        return $this->setOption('data-ignore', (bool)$ignore);
     }
 
     /**
@@ -230,7 +255,7 @@ abstract class ElementAbstract extends \Mmi\OptionObject
      */
     public final function setRequired($required = true)
     {
-        return $this->setOption('data-required', (bool) $required);
+        return $this->setOption('data-required', (bool)$required);
     }
 
     /**
@@ -252,7 +277,9 @@ abstract class ElementAbstract extends \Mmi\OptionObject
     {
         $this->_form = $form;
         //ustawianie ID
-        $this->setId($form->getBaseName() . '-' . $this->getName());
+        $this->setId($form->getBaseName() . '-' . $this->getBaseName());
+        //ustawienie nazwy po nazwie forma
+        $this->setName($this->_form->getBaseName() . '[' . rtrim($this->getBaseName(), '[]') . ']' . (substr($this->getBaseName(), -2) == '[]' ? '[]' : ''));
         return $this;
     }
 
@@ -288,7 +315,7 @@ abstract class ElementAbstract extends \Mmi\OptionObject
      */
     public final function getIgnore()
     {
-        return (bool) $this->getOption('data-ignore');
+        return (bool)$this->getOption('data-ignore');
     }
 
     /**
@@ -324,7 +351,7 @@ abstract class ElementAbstract extends \Mmi\OptionObject
      */
     public final function getRequired()
     {
-        return (bool) $this->getOption('data-required');
+        return (bool)$this->getOption('data-required');
     }
 
     /**
@@ -518,10 +545,6 @@ abstract class ElementAbstract extends \Mmi\OptionObject
     {
         try {
             $html = '';
-            //ustawienie nazwy po nazwie forma
-            if ($this->_form) {
-                $this->setName($this->_form->getBaseName() . '[' . rtrim($this->getName(), '[]') . ']' . (substr($this->getName(), -2) == '[]' ? '[]' : ''));
-            }
             foreach ($this->_renderingOrder as $method) {
                 if (!method_exists($this, $method)) {
                     continue;

--- a/src/Mmi/Form/Element/MultiCheckbox.php
+++ b/src/Mmi/Form/Element/MultiCheckbox.php
@@ -2,7 +2,7 @@
 
 /**
  * Mmi Framework (https://github.com/milejko/mmi.git)
- * 
+ *
  * @link       https://github.com/milejko/mmi.git
  * @copyright  Copyright (c) 2010-2017 Mariusz Miłejko (mariusz@milejko.pl)
  * @license    https://en.wikipedia.org/wiki/BSD_licenses New BSD License
@@ -23,7 +23,6 @@ class MultiCheckbox extends ElementAbstract
     public function __construct($name)
     {
         parent::__construct($name);
-        $this->setBaseName($name);
         $this->setOption('containerClass', trim($this->getOption('containerClass')) . 'multi-box multi-checkbox');
     }
 

--- a/src/Mmi/Form/Element/Select.php
+++ b/src/Mmi/Form/Element/Select.php
@@ -2,7 +2,7 @@
 
 /**
  * Mmi Framework (https://github.com/milejko/mmi.git)
- * 
+ *
  * @link       https://github.com/milejko/mmi.git
  * @copyright  Copyright (c) 2010-2017 Mariusz Miłejko (mariusz@milejko.pl)
  * @license    https://en.wikipedia.org/wiki/BSD_licenses New BSD License
@@ -45,7 +45,7 @@ class Select extends ElementAbstract
     {
         $value = $this->getValue();
         if ($this->issetOption('multiple')) {
-            $this->setName($this->getName() . '[]');
+            $this->setName($this->getBaseName() . '[]');
         }
         unset($this->_options['value']);
         //nagłówek selecta

--- a/src/Mmi/Form/Form.php
+++ b/src/Mmi/Form/Form.php
@@ -129,7 +129,7 @@ abstract class Form extends \Mmi\OptionObject
     public function addElement(\Mmi\Form\Element\ElementAbstract $element)
     {
         //ustawianie opcji na elemencie
-        $this->_elements[$element->getName()] = $element->setForm($this);
+        $this->_elements[$element->getBaseName()] = $element->setForm($this);
         return $this;
     }
 
@@ -225,7 +225,7 @@ abstract class Form extends \Mmi\OptionObject
             if ($element->getDisabled()) {
                 continue;
             }
-            $keyExists = array_key_exists($element->getName(), $data);
+            $keyExists = array_key_exists($element->getBaseName(), $data);
             //selecty multiple i serie checkboxów dostają pusty array jeśli:
             //brak wartości oraz dane z POST
             if (($element instanceof Element\MultiCheckbox || ($element instanceof Element\Select && $element->getOption('multiple'))) && !$keyExists) {
@@ -242,7 +242,7 @@ abstract class Form extends \Mmi\OptionObject
                 continue;
             }
             //ustawianie wartości
-            $element->setValue($data[$element->getName()]);
+            $element->setValue($data[$element->getBaseName()]);
             //aktualizacja na wartość po filtracji
             $element->setValue($element->getFilteredValue());
         }
@@ -269,16 +269,16 @@ abstract class Form extends \Mmi\OptionObject
     {
         //sprawdzenie wartości dla wszystkich elementów
         foreach ($this->getElements() as $element) {
-            if (!array_key_exists($element->getName(), $data)) {
+            if (!array_key_exists($element->getBaseName(), $data)) {
                 continue;
             }
             //checkbox
             if ($element instanceof Element\Checkbox) {
-                $element->getValue() == $data[$element->getName()] ? $element->setChecked() : $element->setChecked(false);
+                $element->getValue() == $data[$element->getBaseName()] ? $element->setChecked() : $element->setChecked(false);
                 continue;
             }
             //ustawianie wartości
-            $element->setValue($data[$element->getName()]);
+            $element->setValue($data[$element->getBaseName()]);
         }
         return $this;
     }
@@ -413,7 +413,7 @@ abstract class Form extends \Mmi\OptionObject
         foreach ($this->getElements() as $element) {
             //niezaznaczony checkbox
             if ($element instanceof Element\Checkbox && !$element->issetChecked()) {
-                $data[$element->getName()] = false;
+                $data[$element->getBaseName()] = false;
                 continue;
             }
             //bez zapisu ignorowanych
@@ -421,7 +421,7 @@ abstract class Form extends \Mmi\OptionObject
                 continue;
             }
             //dodawanie wartości do tabeli
-            $data[$element->getName()] = $element->getValue();
+            $data[$element->getBaseName()] = $element->getValue();
         }
         //ustawianie rekordu na podstawie danych
         $this->_record->setFromArray($data);
@@ -461,6 +461,8 @@ abstract class Form extends \Mmi\OptionObject
         $html = $this->start();
         //rendering poszczególnych elementów
         foreach ($this->_elements as $element) {
+            //ustawienie nazwy po nazwie forma
+            $element->setBaseName($this->getBaseName() . '[' . rtrim($element->getBaseName(), '[]') . ']' . (substr($element->getBaseName(), -2) == '[]' ? '[]' : ''));
             /* @var $element \Mmi\Form\Element\ElementAbstract */
             $html .= $element->__toString();
         }


### PR DESCRIPTION
Celem tego zabiegu jest uniezaleznienie pola 'name' w inputach od nazwy propertki oraz przeniesienie setowania 'name' tam, gdzie faktycznie jest ustawiane, a nie tak jak teraz bylo, ze kazde wywolanie __toString tworzylo kolejna sklejke nazwy