### PR TITLE
fix: do not pass null to \unserialize()

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,26 @@
+# simple environment for running / debugging tests using [Nix](https://nixos.org)
+# to use this file:
+# 1. install Nix: `sh <(curl -L https://nixos.org/nix/install) --no-daemon`
+# 2. Run command: `nix-shell`
+
+{ pkgs ? import <nixpkgs> {}}:
+
+let
+    myPhp = pkgs.php81.buildEnv {
+        extensions = ({ enabled, all }: enabled ++ [ all.xdebug] ++ [ all.apcu ]);
+        extraConfig = ''
+         xdebug.mode=debug
+        '';
+    };
+in
+pkgs.mkShell {
+    packages = [
+        myPhp
+        myPhp.packages.composer
+        myPhp.packages.psysh
+    ];
+
+    shellHook = ''
+      vendor/bin/phpunit --no-coverage
+    '';
+}

--- a/src/Mmi/Cache/Cache.php
+++ b/src/Mmi/Cache/Cache.php
@@ -187,7 +187,7 @@ class Cache implements CacheInterface, SystemCacheInterface
     protected function validateAndPrepareBackendData($key, $data)
     {
         //niepoprawna serializacja
-        if (!($data = \unserialize($data))) {
+        if (!($data = \unserialize($data ?? ''))) {
             return;
         }
         //dane niepoprawne


### PR DESCRIPTION
mmi.ERROR: 8192: unserialize(): Passing null to parameter #1 ($data) of type string is deprecated[/vendor/mmi/mmi/src/Mmi/Cache/Cache.php (190)]