### PR TITLE
fix: do not pass null to \unserialize()

### DIFF
--- a/src/Mmi/Cache/Cache.php
+++ b/src/Mmi/Cache/Cache.php
@@ -187,7 +187,7 @@ class Cache implements CacheInterface, SystemCacheInterface
     protected function validateAndPrepareBackendData($key, $data)
     {
         //niepoprawna serializacja
-        if (!($data = \unserialize($data))) {
+        if (!($data = \unserialize($data ?? ''))) {
             return;
         }
         //dane niepoprawne


### PR DESCRIPTION
mmi.ERROR: 8192: unserialize(): Passing null to parameter #1 ($data) of type string is deprecated[/vendor/mmi/mmi/src/Mmi/Cache/Cache.php (190)]